### PR TITLE
Fix error in list_group url and related method

### DIFF
--- a/location_update/views.py
+++ b/location_update/views.py
@@ -76,7 +76,7 @@ class LocationAPI(APIView):
             ###
             # This won't work without the header
             # 'Content-Type: application/json' :
-            data = request.DATA
+            data = request.data
             ###
 
             # Get the Locations from Data

--- a/location_update/views.py
+++ b/location_update/views.py
@@ -291,7 +291,7 @@ class PlaybackAPI(APIView):
 
 def get_callback_from_request(request):
 	if 'GET' == request.method:
-		return request.GET[u'callback']
+		return request.GET.get('callback', None)
 	elif 'POST' == request.method:
-		return request.POST[u'callback']
+		return request.POST.get('callback', None)
 	return None

--- a/rider/urls.py
+++ b/rider/urls.py
@@ -9,7 +9,7 @@ urlpatterns = patterns('',
 						url(r'^register_push/$',
 							views.RiderPushUpdateAPI.as_view()),
 						# get affinity group data
-						url(r'^list_group/(?P<r_id>\w+)/$', 
+						url(r'^list_group/(?P<r_id>[-\w]+)/$', 
 							views.list_group_view),
 						# create an affinity group
 						url(r'^create_group/$',

--- a/rider/views.py
+++ b/rider/views.py
@@ -133,9 +133,9 @@ def check_code_view(request, aff_id):
 
 def get_callback_from_request(request):
     if 'GET' == request.method:
-        return request.GET[u'callback']
+        return request.GET.get('callback', None)
     elif 'POST' == request.method:
-        return request.POST[u'callback']
+        return request.POST.get('callback', None)
     return None
 
 def write_response(request, data):


### PR DESCRIPTION
Resolves an issue with URLs not matching the data string passed and an issue with callback not being retrieved if it happens to be None (it now defaults to None if it can't be pulled out of the dict, which should be alright since it appears other functions handle that function returning None).